### PR TITLE
infra: Use appium options in capabilities and increased iOS timeouts

### DIFF
--- a/src/browsers/browser-creator.ts
+++ b/src/browsers/browser-creator.ts
@@ -40,7 +40,7 @@ export default abstract class BrowserCreator {
       baseUrl: options.baseUrl,
       waitforTimeout: 5000,
       // As seen in https://github.com/awslabs/wdio-aws-device-farm-service/blob/main/src/launcher.ts#L41
-      connectionRetryTimeout: 180000,
+      connectionRetryTimeout: 300_000,
       connectionRetryCount: 3,
       capabilities: desiredCapabilities,
       protocol: protocol.replace(/:$/, ''),

--- a/src/browsers/devicefarm-mobile.ts
+++ b/src/browsers/devicefarm-mobile.ts
@@ -10,10 +10,9 @@ import type { Capabilities } from '@wdio/types';
 // https://appium.io/docs/en/writing-running-appium/caps/
 const mobileBrowsers: Record<string, Capabilities.DesiredCapabilities> = {
   iOS: {
-    browserName: 'safari',
-    automationName: 'XCUITest',
-    platformName: 'iOS',
-    newCommandTimeout: 240,
+    'appium:automationName': 'XCUITest',
+    'appium:platformName': 'iOS',
+    'appium:newCommandTimeout': 240,
     autoWebview: true,
   },
   Android: {


### PR DESCRIPTION
Uses the appium capabilities as described in documentation
(https://appium.io/docs/en/writing-running-appium/caps/index.html#android-only).
In addition, it increases iOS connection timeouts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
