### PR TITLE
infra increase timeouts

### DIFF
--- a/src/browsers/browser-creator.ts
+++ b/src/browsers/browser-creator.ts
@@ -38,7 +38,9 @@ export default abstract class BrowserCreator {
     const browser = await remote({
       logLevel: options.logLevel,
       baseUrl: options.baseUrl,
-      connectionRetryTimeout: 100000,
+      // iOS devices can take 2-3 minutes to boot
+      connectionRetryTimeout: 240_000,
+      connectionRetryCount: 3,
       waitforTimeout: 5000,
       capabilities: desiredCapabilities,
       protocol: protocol.replace(/:$/, ''),


### PR DESCRIPTION
iOS devices can take between 2-3 minutest to boot up. We will wait for 4 minutes until the device is ready. Compare also: 

https://github.com/awslabs/wdio-aws-device-farm-service/blob/af992d03fca26260b6d77aa8ecc2145f70ba099d/src/launcher.ts#L41



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
