### PR TITLE
chore: Increase the idle timeout for Safari to 180s

### DIFF
--- a/src/browsers/capabilities.ts
+++ b/src/browsers/capabilities.ts
@@ -68,6 +68,7 @@ const defaultCapabilities: Record<string, Capabilities.DesiredCapabilities> = {
   },
   Safari: {
     browserName: 'safari',
+    idleTimeout: 180,
   },
   IE11: {
     browserName: 'internet explorer',


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Safari tests seem to be timing out. Temporary stopgap while we investigate any underlying causes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
