### PR TITLE
feat: Add config to disable test failing on browser errors

### DIFF
--- a/src/use-browser.ts
+++ b/src/use-browser.ts
@@ -9,14 +9,14 @@ type BrowserOptions = {
   seleniumType: string;
   browserCreatorOptions: Record<string, any>;
   webdriverOptions: Partial<WebDriverOptions>;
-  enableBrowserErrors: boolean;
+  skipConsoleErrorsCheck: boolean;
 };
 const options: BrowserOptions = {
   browserName: 'ChromeHeadless',
   seleniumType: 'local',
   browserCreatorOptions: {},
   webdriverOptions: {},
-  enableBrowserErrors: true,
+  skipConsoleErrorsCheck: false,
 };
 
 interface TestFunction {
@@ -39,13 +39,13 @@ function useBrowser(...args: [Partial<WebDriverOptions>, TestFunction] | [TestFu
       }
       await testFn(browser);
       // This method does not exist in w3c protocol
-      if (options.enableBrowserErrors && 'getLogs' in browser) {
+      if (!options.skipConsoleErrorsCheck && 'getLogs' in browser) {
         const logs = (await browser.getLogs('browser')) as Array<{ level: string }>;
         const errors = logs.filter(entry => entry.level === 'SEVERE');
         if (errors.length > 0) {
           throw new Error('Unexpected errors in browser console:\n' + JSON.stringify(errors, null, 2));
         }
-      } else if (options.enableBrowserErrors) {
+      } else if (!options.skipConsoleErrorsCheck) {
         console.warn('Unable to check browser console, webdriver does not support this feature');
       }
     } finally {

--- a/src/use-browser.ts
+++ b/src/use-browser.ts
@@ -9,12 +9,14 @@ type BrowserOptions = {
   seleniumType: string;
   browserCreatorOptions: Record<string, any>;
   webdriverOptions: Partial<WebDriverOptions>;
+  enableBrowserErrors: boolean;
 };
 const options: BrowserOptions = {
   browserName: 'ChromeHeadless',
   seleniumType: 'local',
   browserCreatorOptions: {},
   webdriverOptions: {},
+  enableBrowserErrors: true,
 };
 
 interface TestFunction {
@@ -37,13 +39,13 @@ function useBrowser(...args: [Partial<WebDriverOptions>, TestFunction] | [TestFu
       }
       await testFn(browser);
       // This method does not exist in w3c protocol
-      if ('getLogs' in browser) {
+      if (options.enableBrowserErrors && 'getLogs' in browser) {
         const logs = (await browser.getLogs('browser')) as Array<{ level: string }>;
         const errors = logs.filter(entry => entry.level === 'SEVERE');
         if (errors.length > 0) {
           throw new Error('Unexpected errors in browser console:\n' + JSON.stringify(errors, null, 2));
         }
-      } else {
+      } else if (options.enableBrowserErrors) {
         console.warn('Unable to check browser console, webdriver does not support this feature');
       }
     } finally {

--- a/test/use-browser.test.js
+++ b/test/use-browser.test.js
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 const { promisify } = require('util');
 const useBrowser = require('../src/use-browser').default;
+const { configure } = require('../src/use-browser');
 const { getViewportSize } = require('../src/browser-scripts');
 const delay = promisify(setTimeout);
 
@@ -46,6 +47,18 @@ test('propagates an error happened in test', async () => {
   await expect(brokenTest()).rejects.toThrowError(
     /Can't call click on element with selector "#not-existing" because element wasn't found/
   );
+});
+
+test('should not fail if there are errors in browser console and enableBrowserErrors is disabled', async () => {
+  configure({ enableBrowserErrors: false });
+  function errorTest() {
+    return useBrowser(async browser => {
+      await browser.url('./index.html');
+      await (await browser.$('#error-button')).click();
+    })();
+  }
+  await expect(errorTest()).resolves.toBeUndefined();
+  configure({ enableBrowserErrors: true });
 });
 
 test('should fail if there are errors in browser console', async () => {

--- a/test/use-browser.test.js
+++ b/test/use-browser.test.js
@@ -50,7 +50,7 @@ test('propagates an error happened in test', async () => {
 });
 
 test('should not fail if there are errors in browser console and enableBrowserErrors is disabled', async () => {
-  configure({ enableBrowserErrors: false });
+  configure({ skipConsoleErrorsCheck: true });
   function errorTest() {
     return useBrowser(async browser => {
       await browser.url('./index.html');
@@ -58,7 +58,7 @@ test('should not fail if there are errors in browser console and enableBrowserEr
     })();
   }
   await expect(errorTest()).resolves.toBeUndefined();
-  configure({ enableBrowserErrors: true });
+  configure({ skipConsoleErrorsCheck: false });
 });
 
 test('should fail if there are errors in browser console', async () => {


### PR DESCRIPTION
*Description of changes:*

Add `enableBrowserErrors` option to allow test runners to not fail on browser errors 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
