### PR TITLE
feat: Add live announcements util to base page

### DIFF
--- a/src/browser-scripts/live-announcements.ts
+++ b/src/browser-scripts/live-announcements.ts
@@ -4,10 +4,9 @@
 interface ExtendedWindow extends Window {
   __liveAnnouncements?: string[];
 }
+declare const window: ExtendedWindow;
 
 export function initLiveAnnouncementsObserver() {
-  const extendedWindow = window as ExtendedWindow;
-
   const observer = new MutationObserver(mutationList => {
     for (const mutation of mutationList) {
       if (
@@ -16,10 +15,10 @@ export function initLiveAnnouncementsObserver() {
         mutation.target.hasAttribute('aria-live') &&
         mutation.target.textContent
       ) {
-        if (!extendedWindow.__liveAnnouncements) {
-          extendedWindow.__liveAnnouncements = [];
+        if (!window.__liveAnnouncements) {
+          window.__liveAnnouncements = [];
         }
-        extendedWindow.__liveAnnouncements.push(mutation.target.textContent);
+        window.__liveAnnouncements.push(mutation.target.textContent);
       }
     }
   });
@@ -27,9 +26,9 @@ export function initLiveAnnouncementsObserver() {
 }
 
 export function getLiveAnnouncements() {
-  return (window as ExtendedWindow).__liveAnnouncements ?? [];
+  return window.__liveAnnouncements ?? [];
 }
 
 export function clearLiveAnnouncements() {
-  (window as ExtendedWindow).__liveAnnouncements = [];
+  window.__liveAnnouncements = [];
 }

--- a/src/browser-scripts/live-announcements.ts
+++ b/src/browser-scripts/live-announcements.ts
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+interface ExtendedWindow extends Window {
+  __liveAnnouncements?: string[];
+}
+
+export function initLiveAnnouncementsObserver() {
+  const extendedWindow = window as ExtendedWindow;
+
+  const observer = new MutationObserver(mutationList => {
+    for (const mutation of mutationList) {
+      if (
+        mutation.type === 'childList' &&
+        mutation.target instanceof HTMLElement &&
+        mutation.target.hasAttribute('aria-live') &&
+        mutation.target.textContent
+      ) {
+        if (!extendedWindow.__liveAnnouncements) {
+          extendedWindow.__liveAnnouncements = [];
+        }
+        extendedWindow.__liveAnnouncements.push(mutation.target.textContent);
+      }
+    }
+  });
+  observer.observe(document.body, { attributes: false, childList: true, subtree: true });
+}
+
+export function getLiveAnnouncements() {
+  return (window as ExtendedWindow).__liveAnnouncements ?? [];
+}
+
+export function clearLiveAnnouncements() {
+  (window as ExtendedWindow).__liveAnnouncements = [];
+}

--- a/test/fixtures/test-page-object.html
+++ b/test/fixtures/test-page-object.html
@@ -31,7 +31,7 @@
     </div>
     <button id="button">Click me</button>
     <button id="update-live-announcement-button">Update live announcement</button>
-    <div aria-live="polite" id="live-announcement" style="visibility: none"></div>
+    <div aria-live="polite" id="live-announcement"></div>
 
     <button id="hover-button">Hover me</button>
     <span id="hover-span">Hover success</span>

--- a/test/fixtures/test-page-object.html
+++ b/test/fixtures/test-page-object.html
@@ -30,6 +30,7 @@
       <div style="width: 120%">Some scrollable text</div>
     </div>
     <button id="button">Click me</button>
+    <button id="update-live-announcement-button">Update live announcement</button>
     <div aria-live="polite" id="live-announcement" style="visibility: none"></div>
 
     <button id="hover-button">Hover me</button>
@@ -42,13 +43,17 @@
 
     <p style="height: 800px">Strut to make the page scroll</p>
     <script>
-      var liveAnnouncementUpdateIndex = 0;
       var button = document.getElementById('button');
       button.addEventListener('click', function () {
         var message = document.createElement('span');
         message.id = 'click-message';
         message.textContent = 'Clicked!';
         document.body.insertBefore(message, button.nextElementSibling);
+      });
+
+      var liveAnnouncementUpdateIndex = 0;
+      var updateLiveAnnouncementButton = document.getElementById('update-live-announcement-button');
+      updateLiveAnnouncementButton.addEventListener('click', function () {
         document.getElementById('live-announcement').textContent = `update ${++liveAnnouncementUpdateIndex}`;
       });
     </script>

--- a/test/fixtures/test-page-object.html
+++ b/test/fixtures/test-page-object.html
@@ -30,6 +30,7 @@
       <div style="width: 120%">Some scrollable text</div>
     </div>
     <button id="button">Click me</button>
+    <div aria-live="polite" id="live-announcement" style="visibility: none"></div>
 
     <button id="hover-button">Hover me</button>
     <span id="hover-span">Hover success</span>
@@ -41,12 +42,14 @@
 
     <p style="height: 800px">Strut to make the page scroll</p>
     <script>
+      var liveAnnouncementUpdateIndex = 0;
       var button = document.getElementById('button');
       button.addEventListener('click', function () {
         var message = document.createElement('span');
         message.id = 'click-message';
         message.textContent = 'Clicked!';
         document.body.insertBefore(message, button.nextElementSibling);
+        document.getElementById('live-announcement').textContent = `update ${++liveAnnouncementUpdateIndex}`;
       });
     </script>
   </body>

--- a/test/page-object.test.js
+++ b/test/page-object.test.js
@@ -276,8 +276,8 @@ test(
   'live announcements',
   setupTest(async page => {
     await page.initLiveAnnouncementsObserver();
-    await page.click('update-live-announcement-button');
-    await page.click('update-live-announcement-button');
+    await page.click('#update-live-announcement-button');
+    await page.click('#update-live-announcement-button');
     await expect(page.getLiveAnnouncements()).resolves.toEqual(['update 1', 'update 2']);
     await page.clearLiveAnnouncements();
     await expect(page.getLiveAnnouncements()).resolves.toEqual([]);

--- a/test/page-object.test.js
+++ b/test/page-object.test.js
@@ -271,3 +271,15 @@ test(
     await page.waitForVisible('#click-message');
   })
 );
+
+test(
+  'live announcements',
+  setupTest(async page => {
+    await page.initLiveAnnouncementsObserver();
+    await page.click('button');
+    await page.click('button');
+    await expect(page.getLiveAnnouncements()).resolves.toEqual(['update 1', 'update 2']);
+    await page.clearLiveAnnouncements();
+    await expect(page.getLiveAnnouncements()).resolves.toEqual([]);
+  })
+);

--- a/test/page-object.test.js
+++ b/test/page-object.test.js
@@ -276,8 +276,8 @@ test(
   'live announcements',
   setupTest(async page => {
     await page.initLiveAnnouncementsObserver();
-    await page.click('button');
-    await page.click('button');
+    await page.click('update-live-announcement-button');
+    await page.click('update-live-announcement-button');
     await expect(page.getLiveAnnouncements()).resolves.toEqual(['update 1', 'update 2']);
     await page.clearLiveAnnouncements();
     await expect(page.getLiveAnnouncements()).resolves.toEqual([]);


### PR DESCRIPTION
This util was first introduced in the board components to test against live announcements issued on the page, see: https://github.com/cloudscape-design/board-components/blob/main/test/functional/board-layout/live-announcements.test.ts.

Adding this util here would allow to reuse it for other projects. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
