### PR TITLE
chore: Update screenshot max page height

### DIFF
--- a/src/page-objects/full-page-screenshot.ts
+++ b/src/page-objects/full-page-screenshot.ts
@@ -6,7 +6,7 @@ import mergeImages from '../image-utils/merge';
 import { waitForTimerAndAnimationFrame } from './browser-scripts';
 import { calculateIosTopOffset, getPuppeteer } from './utils';
 
-const MAX_SCREENSHOT_HEIGHT = 20000;
+const MAX_SCREENSHOT_HEIGHT = 16000;
 
 async function scroll(browser: WebdriverIO.Browser, topOffset: number) {
   await browser.execute(windowScrollTo, topOffset, 0);


### PR DESCRIPTION
### Description

The current max page size for the screenshots is out of date (reduced from 20000 to 16000). This PR updates it.

There is also a corresponding [PR](https://github.com/cloudscape-design/components/pull/777) for components, as these values should be kept in sync.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
