### PR TITLE
feat: add isClickable method

### DIFF
--- a/src/page-objects/base.ts
+++ b/src/page-objects/base.ts
@@ -187,6 +187,11 @@ export default class BasePageObject {
     return elements[0].isDisplayed();
   }
 
+  async isClickable(selector: string) {
+    const element = await this.browser.$(selector);
+    return element.isClickable();
+  }
+
   async getElementAttribute(selector: string, attributeName: string) {
     const element = await this.browser.$(selector);
     return element.getAttribute(attributeName);

--- a/test/fixtures/test-page-object.html
+++ b/test/fixtures/test-page-object.html
@@ -34,6 +34,7 @@
     <div aria-live="polite" id="live-announcement"></div>
 
     <button id="hover-button">Hover me</button>
+    <button id="disabled-button" disabled="true">Hover me</button>
     <span id="hover-span">Hover success</span>
 
     <input id="input-1" />

--- a/test/page-object.test.js
+++ b/test/page-object.test.js
@@ -175,6 +175,14 @@ test(
 );
 
 test(
+  'isClickable',
+  setupTest(async page => {
+    await expect(page.isClickable('#hover-button')).resolves.toBe(true);
+    await expect(page.isClickable('#disabled-button')).resolves.toBe(false);
+  })
+);
+
+test(
   'windowScrollTo/getWindowScroll',
   setupTest(async page => {
     await page.windowScrollTo({ top: 40 });


### PR DESCRIPTION
*Description of changes:*

Added `page.isClickable('.selector')` method to reuse across tests

Tried `element.isEnabled()` too, but it is not very universal (does not consider `pointer-events: none`, which we use for disabled buttons with hrefs). `isClickable` covers more cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
