### PR TITLE
feat: Update iOS screenshots to only support iOS 15+

### DIFF
--- a/src/page-objects/utils.ts
+++ b/src/page-objects/utils.ts
@@ -10,9 +10,6 @@ export function getElementCenter(rect: ElementRect): { x: number; y: number } {
   };
 }
 
-// This is the pixel value *before* applying the device pixel ratio
-const iosAddressBarHeight = 50;
-
 // Device specific sizes for iOS devices. Models before iPhone X are covered by the default value.
 // Viewport values taken from https://yesviz.com/iphones.php
 const iosDeviceConfig = [
@@ -42,8 +39,10 @@ const iosDeviceConfig = [
   },
 ];
 
-// Screenshots on iOS include all iOS UI elements like toolbars and navigation, so we need to
+// Screenshots on iOS include all iOS UI elements like toolbars, so we need to
 // cut them out of screenshots. This function provides relevant offsets.
+// As of iOS 15, the navigation bar has moved to the bottom, so it's no longer
+// relevant when calculating the top offset.
 export function calculateIosTopOffset(
   dimensions: Pick<ViewportSize, 'screenWidth' | 'screenHeight' | 'pixelRatio'>
 ): number {
@@ -60,9 +59,7 @@ export function calculateIosTopOffset(
     statusBarHeight = deviceConfig.statusBarHeight;
   }
 
-  const addressBarHeight = iosAddressBarHeight * dimensions.pixelRatio;
-
-  return statusBarHeight + addressBarHeight;
+  return statusBarHeight;
 }
 
 export async function getPuppeteer(browser: WebdriverIO.Browser) {

--- a/test/page-object.test.js
+++ b/test/page-object.test.js
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 const { ScreenshotPageObject } = require('../src/page-objects');
+const { calculateIosTopOffset } = require('../src/page-objects/utils');
 const useBrowser = require('../src/use-browser').default;
 
 function setupTest(testFn) {
@@ -291,3 +292,18 @@ test(
     await expect(page.getLiveAnnouncements()).resolves.toEqual([]);
   })
 );
+
+describe('calculateIosTopOffset', () => {
+  test('falls back to default offset if device cannot be identified', () => {
+    expect(calculateIosTopOffset({ screenWidth: 99, screenHeight: 99, pixelRatio: 1 })).toBe(20);
+    expect(calculateIosTopOffset({ screenWidth: 99, screenHeight: 99, pixelRatio: 2 })).toBe(40);
+  });
+
+  test('returns offsets for recognized devices', () => {
+    // iPhone 12 Pro
+    expect(calculateIosTopOffset({ screenWidth: 390, screenHeight: 844, pixelRatio: 2 })).toBe(141);
+
+    // iPhone 11 Pro
+    expect(calculateIosTopOffset({ screenWidth: 375, screenHeight: 812, pixelRatio: 2 })).toBe(132);
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
So far, the iOS screenshot utils assume that the Safari navigation bar is at the top of the screen and therefore needs to be cut out of every screenshot. This is no longer the case starting with iOS 15.

This change removes the need for considering the navigation bar and therefore adds support for iOS 15 and drops support for iOS 14 and below.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
