### PR TITLE
fix: Remove idleTimeout capability from local Safari config

### DIFF
--- a/src/browsers/capabilities.ts
+++ b/src/browsers/capabilities.ts
@@ -68,7 +68,6 @@ const defaultCapabilities: Record<string, Capabilities.DesiredCapabilities> = {
   },
   Safari: {
     browserName: 'safari',
-    idleTimeout: 180,
   },
   IE11: {
     browserName: 'internet explorer',


### PR DESCRIPTION
Currently local Safari run fails with this error: `Illegal key values seen in w3c capabilities: [idleTimeout] Make sure to add vendor prefix like "goog:", "appium:", "moz:", etc to non W3C capabilities.`

This config is non-standard and Selenium declines such request.



---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
