### PR TITLE
chore: Convert tests to typescript

### DIFF
--- a/__mocks__/aws-sdk/clients/devicefarm.js
+++ b/__mocks__/aws-sdk/clients/devicefarm.js
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 const responses = {
-  pass: () => Promise.resolve({ url: 'http://localhost:4444' }),
+  pass: () => Promise.resolve({ url: 'http://localhost:4444/devicefarm-test-grid' }),
   invalid: () => Promise.resolve({ invalid: true }),
   throttling: () => {
     const error = new Error('ThrottlingException');

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/pixelmatch": "^5.2.4",
         "@typescript-eslint/eslint-plugin": "^5.41.0",
         "@typescript-eslint/parser": "^5.41.0",
+        "@wdio/types": "7.26.0",
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-header": "^3.1.1",
@@ -923,12 +924,12 @@
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.3.1.tgz",
-      "integrity": "sha512-wlrznINZI5sMjwvUoLVk617ll/UYfGIZNxmbU+Pa7wmkL4vYzhV9R2pwVqUh4NWWuLQWkI8+8mOkxs//prKQ3g==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
+      "integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^29.2.0"
+        "jest-get-type": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1010,12 +1011,12 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
       "dev": true,
       "dependencies": {
-        "@sinclair/typebox": "^0.24.1"
+        "@sinclair/typebox": "^0.25.16"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1092,12 +1093,12 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.3.1.tgz",
-      "integrity": "sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
+      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.0.0",
+        "@jest/schemas": "^29.4.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -1212,9 +1213,9 @@
       "dev": true
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.51",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
-      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
       "dev": true
     },
     "node_modules/@sindresorhus/is": {
@@ -1768,9 +1769,9 @@
       }
     },
     "node_modules/@wdio/types/node_modules/@types/node": {
-      "version": "18.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
+      "version": "18.16.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.18.tgz",
+      "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw=="
     },
     "node_modules/@wdio/utils": {
       "version": "7.26.0",
@@ -2883,9 +2884,9 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
-      "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3406,16 +3407,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.3.1.tgz",
-      "integrity": "sha512-gGb1yTgU30Q0O/tQq+z30KBWv24ApkMgFUpvKBkyLUBL68Wv8dHdJxTBZFl/iT8K/bqDHvUYRH6IIN3rToopPA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
+      "integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.3.1",
-        "jest-get-type": "^29.2.0",
-        "jest-matcher-utils": "^29.3.1",
-        "jest-message-util": "^29.3.1",
-        "jest-util": "^29.3.1"
+        "@jest/expect-utils": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4753,15 +4754,15 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.3.1.tgz",
-      "integrity": "sha512-vU8vyiO7568tmin2lA3r2DP8oRvzhvRcD4DjpXc6uGveQodyk7CKLhQlCSiwgx3g0pFaE88/KLZ0yaTWMc4Uiw==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
+      "integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.3.1",
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.3.1"
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4813,9 +4814,9 @@
       }
     },
     "node_modules/jest-get-type": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
-      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4860,33 +4861,33 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.3.1.tgz",
-      "integrity": "sha512-fkRMZUAScup3txIKfMe3AIZZmPEjWEdsPJFK3AIy5qRohWqQFg1qrmKfYXR9qEkNc7OdAu2N4KPHibEmy4HPeQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
+      "integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.3.1",
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.3.1"
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.3.1.tgz",
-      "integrity": "sha512-lMJTbgNcDm5z+6KDxWtqOFWlGQxD6XaYwBqHR8kmpkP+WWWG90I35kdtQHY67Ay5CSuydkTBbJG+tH9JShFCyA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
+      "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.3.1",
+        "@jest/types": "^29.5.0",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.3.1",
+        "pretty-format": "^29.5.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -5068,12 +5069,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.3.1.tgz",
-      "integrity": "sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
+      "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.3.1",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -6729,12 +6730,12 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
-      "integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.0.0",
+        "@jest/schemas": "^29.4.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -8479,9 +8480,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -9245,12 +9246,12 @@
       }
     },
     "@jest/expect-utils": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.3.1.tgz",
-      "integrity": "sha512-wlrznINZI5sMjwvUoLVk617ll/UYfGIZNxmbU+Pa7wmkL4vYzhV9R2pwVqUh4NWWuLQWkI8+8mOkxs//prKQ3g==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
+      "integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^29.2.0"
+        "jest-get-type": "^29.4.3"
       }
     },
     "@jest/fake-timers": {
@@ -9312,12 +9313,12 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
       "dev": true,
       "requires": {
-        "@sinclair/typebox": "^0.24.1"
+        "@sinclair/typebox": "^0.25.16"
       }
     },
     "@jest/source-map": {
@@ -9379,12 +9380,12 @@
       }
     },
     "@jest/types": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.3.1.tgz",
-      "integrity": "sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
+      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
       "dev": true,
       "requires": {
-        "@jest/schemas": "^29.0.0",
+        "@jest/schemas": "^29.4.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -9478,9 +9479,9 @@
       "dev": true
     },
     "@sinclair/typebox": {
-      "version": "0.24.51",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
-      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
       "dev": true
     },
     "@sindresorhus/is": {
@@ -9906,9 +9907,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "18.11.10",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-          "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
+          "version": "18.16.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.18.tgz",
+          "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw=="
         }
       }
     },
@@ -10743,9 +10744,9 @@
       "integrity": "sha512-Np2EaEFlSOev03f5ySurGi3/z8YWOwsfSPPSDTbf7zlBY77SxBWfkFf41IUmkvfkeckX8XVW9hes1jVwALNAaA=="
     },
     "diff-sequences": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
-      "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
       "dev": true
     },
     "dir-glob": {
@@ -11133,16 +11134,16 @@
       "dev": true
     },
     "expect": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.3.1.tgz",
-      "integrity": "sha512-gGb1yTgU30Q0O/tQq+z30KBWv24ApkMgFUpvKBkyLUBL68Wv8dHdJxTBZFl/iT8K/bqDHvUYRH6IIN3rToopPA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
+      "integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
       "dev": true,
       "requires": {
-        "@jest/expect-utils": "^29.3.1",
-        "jest-get-type": "^29.2.0",
-        "jest-matcher-utils": "^29.3.1",
-        "jest-message-util": "^29.3.1",
-        "jest-util": "^29.3.1"
+        "@jest/expect-utils": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0"
       }
     },
     "extract-zip": {
@@ -12072,15 +12073,15 @@
       }
     },
     "jest-diff": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.3.1.tgz",
-      "integrity": "sha512-vU8vyiO7568tmin2lA3r2DP8oRvzhvRcD4DjpXc6uGveQodyk7CKLhQlCSiwgx3g0pFaE88/KLZ0yaTWMc4Uiw==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
+      "integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.3.1",
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.3.1"
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
       }
     },
     "jest-docblock": {
@@ -12120,9 +12121,9 @@
       }
     },
     "jest-get-type": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
-      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
       "dev": true
     },
     "jest-haste-map": {
@@ -12156,30 +12157,30 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.3.1.tgz",
-      "integrity": "sha512-fkRMZUAScup3txIKfMe3AIZZmPEjWEdsPJFK3AIy5qRohWqQFg1qrmKfYXR9qEkNc7OdAu2N4KPHibEmy4HPeQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
+      "integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.3.1",
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.3.1"
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
       }
     },
     "jest-message-util": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.3.1.tgz",
-      "integrity": "sha512-lMJTbgNcDm5z+6KDxWtqOFWlGQxD6XaYwBqHR8kmpkP+WWWG90I35kdtQHY67Ay5CSuydkTBbJG+tH9JShFCyA==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
+      "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.3.1",
+        "@jest/types": "^29.5.0",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.3.1",
+        "pretty-format": "^29.5.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       }
@@ -12327,12 +12328,12 @@
       }
     },
     "jest-util": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.3.1.tgz",
-      "integrity": "sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
+      "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^29.3.1",
+        "@jest/types": "^29.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -13557,12 +13558,12 @@
       }
     },
     "pretty-format": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
-      "integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
       "dev": true,
       "requires": {
-        "@jest/schemas": "^29.0.0",
+        "@jest/schemas": "^29.4.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -14853,9 +14854,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "requires": {
         "cliui": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@types/pixelmatch": "^5.2.4",
         "@typescript-eslint/eslint-plugin": "^5.41.0",
         "@typescript-eslint/parser": "^5.41.0",
-        "@wdio/types": "7.26.0",
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-header": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prestart": "npm run clean && npm run build",
     "start": "node demo",
     "pretest": "npm run clean && npm run build",
-    "test": "run-p -r start-http-server 'run-tests --scripts-prepend-node-path'",
+    "test": "run-p -r start-http-server run-tests",
     "run-tests": "wait-on http://localhost:9615 && jest",
     "start-http-server": "http-server test/fixtures --port=9615 --silent",
     "lint": "eslint --ext=ts,js --ignore-path .gitignore .",
@@ -41,7 +41,6 @@
     "@types/pixelmatch": "^5.2.4",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
-    "@wdio/types": "7.26.0",
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-header": "^3.1.1",
@@ -70,7 +69,6 @@
     ]
   },
   "jest": {
-    "preset": "ts-jest",
     "testEnvironment": "node",
     "collectCoverage": true,
     "collectCoverageFrom": [
@@ -84,10 +82,15 @@
       "lcov",
       "cobertura"
     ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/test/utils/setup.js"
-    ],
-    "globalSetup": "<rootDir>/test/utils/start-chromedriver.js",
-    "globalTeardown": "<rootDir>/test/utils/stop-chromedriver.js"
+    "globalSetup": "<rootDir>/test/utils/start-chromedriver.ts",
+    "globalTeardown": "<rootDir>/test/utils/stop-chromedriver.ts",
+    "transform": {
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "tsconfig": "tsconfig.test.json"
+        }
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/pixelmatch": "^5.2.4",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
+    "@wdio/types": "7.26.0",
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-header": "^3.1.1",

--- a/src/browsers/browser-creator.ts
+++ b/src/browsers/browser-creator.ts
@@ -29,7 +29,7 @@ export default abstract class BrowserCreator {
   // eslint-disable-next-line no-unused-vars
   constructor(protected browserName: string, protected options: Record<string, any>) {}
 
-  protected async setupBrowser(overrides: Partial<WebDriverOptions>) {
+  async setupBrowser(overrides: Partial<WebDriverOptions>) {
     const options = merge({}, defaultOptions, overrides);
     const desiredCapabilities = merge({}, this.__getCapabilities(), overrides.capabilities);
     const { protocol, hostname, port, pathname } = await this.__getBrowserUrl();
@@ -74,6 +74,6 @@ export default abstract class BrowserCreator {
     }
   }
 
-  protected abstract __getBrowserUrl(): Promise<URL>;
-  protected abstract __getCapabilities(): WebDriver.DesiredCapabilities;
+  abstract __getBrowserUrl(): Promise<URL>;
+  abstract __getCapabilities(): WebDriver.DesiredCapabilities;
 }

--- a/src/browsers/browser-creator.ts
+++ b/src/browsers/browser-creator.ts
@@ -26,10 +26,9 @@ const defaultOptions: WebDriverOptions = {
 };
 
 export default abstract class BrowserCreator {
-  // eslint-disable-next-line no-unused-vars
   constructor(protected browserName: string, protected options: Record<string, any>) {}
 
-  async setupBrowser(overrides: Partial<WebDriverOptions>) {
+  protected async setupBrowser(overrides: Partial<WebDriverOptions>) {
     const options = merge({}, defaultOptions, overrides);
     const desiredCapabilities = merge({}, this.__getCapabilities(), overrides.capabilities);
     const { protocol, hostname, port, pathname } = await this.__getBrowserUrl();
@@ -59,7 +58,7 @@ export default abstract class BrowserCreator {
     return browser;
   }
 
-  async getBrowser(options: Partial<WebDriverOptions>) {
+  public async getBrowser(options: Partial<WebDriverOptions>) {
     try {
       return this.setupBrowser(options);
     } catch (error) {
@@ -74,6 +73,6 @@ export default abstract class BrowserCreator {
     }
   }
 
-  abstract __getBrowserUrl(): Promise<URL>;
-  abstract __getCapabilities(): WebDriver.DesiredCapabilities;
+  protected abstract __getBrowserUrl(): Promise<URL>;
+  protected abstract __getCapabilities(): WebDriver.DesiredCapabilities;
 }

--- a/src/browsers/browserstack.ts
+++ b/src/browsers/browserstack.ts
@@ -112,7 +112,7 @@ export default class BrowserStackBrowserCreator extends BrowserCreator {
     return new URL(browserStackHub);
   }
 
-  __getCapabilities(): Capabilities.DesiredCapabilities {
+  protected __getCapabilities(): Capabilities.DesiredCapabilities {
     const capabilities = getCapability(this.browserName, browsers);
     const browserstackOptions = this.options as BrowserstackOptions;
     return {

--- a/src/browsers/devicefarm.ts
+++ b/src/browsers/devicefarm.ts
@@ -8,15 +8,6 @@ import { AWSError } from 'aws-sdk/lib/error';
 import BrowserCreator from './browser-creator';
 import defaultCapabilities, { getCapability } from './capabilities';
 import { FatalError } from '../exceptions';
-import type { Capabilities } from '@wdio/types';
-
-// This uses undocumented options which prevents proper typing
-const capabilities: Record<string, Capabilities.DesiredCapabilities> = {
-  ...defaultCapabilities,
-  IE11: {
-    browserName: 'internet explorer',
-  },
-};
 
 export interface DevicefarmOptions {
   retryCount?: number;
@@ -26,7 +17,7 @@ export interface DevicefarmOptions {
 }
 
 export default class DevicefarmBrowserCreator extends BrowserCreator {
-  protected async __getBrowserUrl(): Promise<URL> {
+  async __getBrowserUrl(): Promise<URL> {
     const options = this.options as DevicefarmOptions;
     const client = new DeviceFarm({ credentials: options.credentials, region: 'us-west-2' });
 
@@ -57,8 +48,8 @@ export default class DevicefarmBrowserCreator extends BrowserCreator {
     return new URL(response.url);
   }
 
-  protected __getCapabilities() {
-    return getCapability(this.browserName, capabilities);
+  __getCapabilities() {
+    return getCapability(this.browserName, defaultCapabilities);
   }
 }
 

--- a/src/browsers/devicefarm.ts
+++ b/src/browsers/devicefarm.ts
@@ -17,7 +17,7 @@ export interface DevicefarmOptions {
 }
 
 export default class DevicefarmBrowserCreator extends BrowserCreator {
-  async __getBrowserUrl(): Promise<URL> {
+  protected async __getBrowserUrl(): Promise<URL> {
     const options = this.options as DevicefarmOptions;
     const client = new DeviceFarm({ credentials: options.credentials, region: 'us-west-2' });
 
@@ -48,7 +48,7 @@ export default class DevicefarmBrowserCreator extends BrowserCreator {
     return new URL(response.url);
   }
 
-  __getCapabilities() {
+  protected __getCapabilities() {
     return getCapability(this.browserName, defaultCapabilities);
   }
 }

--- a/src/page-objects/base.ts
+++ b/src/page-objects/base.ts
@@ -241,8 +241,4 @@ export default class BasePageObject {
   async clearLiveAnnouncements() {
     await this.browser.execute(liveAnnouncements.clearLiveAnnouncements);
   }
-
-  getBrowser() {
-    return this.browser;
-  }
 }

--- a/src/page-objects/base.ts
+++ b/src/page-objects/base.ts
@@ -241,4 +241,8 @@ export default class BasePageObject {
   async clearLiveAnnouncements() {
     await this.browser.execute(liveAnnouncements.clearLiveAnnouncements);
   }
+
+  getBrowser() {
+    return this.browser;
+  }
 }

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const getBrowserCreator = require('../src/browser').default;
+import getBrowserCreator from '../src/browser';
 
 test('should throw on unknown type of selenium provider', () => {
   expect(() => getBrowserCreator('Chrome', 'foo', {})).toThrow('Incorrect selenium provider: foo');
 });
 
 test('should throw on unknown browser', async () => {
-  const creator = getBrowserCreator('Edge', 'local');
+  const creator = getBrowserCreator('Edge', 'local', {});
   await expect(creator.getBrowser({})).rejects.toThrow('Browser Edge is not supported in this provider');
 });

--- a/test/browsers/browserstack.test.ts
+++ b/test/browsers/browserstack.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const BrowserStackBrowserCreator = require('../../src/browsers/browserstack').default;
+import BrowserStackBrowserCreator from '../../src/browsers/browserstack';
 
 const browserName = 'Chrome';
 const browserOptions = {
@@ -11,14 +11,6 @@ const browserOptions = {
   nSecSleepBeforeRetry: 0.001,
 };
 
-BrowserStackBrowserCreator.prototype.setupBrowser = jest.fn().mockImplementation(options => {
-  const errorMessage = options.makeQueueFullErrorForTesting
-    ? 'All parallel tests are currently in use, including the queued tests. Please wait to finish or upgrade your plan to add more sessions.'
-    : 'Some other error that we should accept without retrying';
-
-  return Promise.reject(new Error(errorMessage));
-});
-
 describe('BrowserStack browserCreator ', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -26,18 +18,28 @@ describe('BrowserStack browserCreator ', () => {
 
   test('should try to reconnect in case of a full BrowserStack queue', async () => {
     const browserCreator = new BrowserStackBrowserCreator(browserName, browserOptions);
-    expect(browserCreator.setupBrowser.mock.calls.length).toBe(0);
-    await expect(browserCreator.getBrowser({ makeQueueFullErrorForTesting: true })).rejects.toThrow(
-      'All parallel tests are currently in use'
-    );
-    expect(browserCreator.setupBrowser.mock.calls.length).toBe(11);
+    const setupBrowserSpy = jest.spyOn(browserCreator, 'setupBrowser').mockImplementation(() => {
+      return Promise.reject(
+        new Error(
+          'All parallel tests are currently in use, including the queued tests. Please wait to finish or upgrade your plan to add more sessions.'
+        )
+      );
+    });
+
+    expect(setupBrowserSpy).toHaveBeenCalledTimes(0);
+    await expect(browserCreator.getBrowser({})).rejects.toThrow('All parallel tests are currently in use');
+    expect(setupBrowserSpy).toHaveBeenCalledTimes(11);
   });
 
   test('should not try to reconnect if any other error than a full BrowserStack queue gets thrown', async () => {
     const browserCreator = new BrowserStackBrowserCreator(browserName, browserOptions);
-    expect(browserCreator.setupBrowser.mock.calls.length).toBe(0);
+    const setupBrowserSpy = jest.spyOn(browserCreator, 'setupBrowser').mockImplementation(() => {
+      return Promise.reject(new Error('Some other error that we should accept without retrying'));
+    });
+
+    expect(setupBrowserSpy).toHaveBeenCalledTimes(0);
     await expect(browserCreator.getBrowser({})).rejects.toThrow();
-    expect(browserCreator.setupBrowser.mock.calls.length).toBe(1);
+    expect(setupBrowserSpy).toHaveBeenCalledTimes(1);
   });
 
   test('should use BrowserStack hub url', async () => {

--- a/test/browsers/browserstack.test.ts
+++ b/test/browsers/browserstack.test.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { remoteMock } from './wdio-mock';
 import BrowserStackBrowserCreator from '../../src/browsers/browserstack';
 
 const browserName = 'Chrome';
@@ -9,6 +10,8 @@ const browserOptions = {
   needsKeyboard: false,
   implicitTimeout: 100,
   nSecSleepBeforeRetry: 0.001,
+  projectName: 'project',
+  credentials: { user: 'my-user', key: 'my-key' },
 };
 
 describe('BrowserStack browserCreator ', () => {
@@ -18,50 +21,44 @@ describe('BrowserStack browserCreator ', () => {
 
   test('should try to reconnect in case of a full BrowserStack queue', async () => {
     const browserCreator = new BrowserStackBrowserCreator(browserName, browserOptions);
-    const setupBrowserSpy = jest.spyOn(browserCreator, 'setupBrowser').mockImplementation(() => {
-      return Promise.reject(
+    remoteMock.mockReturnValue(
+      Promise.reject(
         new Error(
           'All parallel tests are currently in use, including the queued tests. Please wait to finish or upgrade your plan to add more sessions.'
         )
-      );
-    });
-
-    expect(setupBrowserSpy).toHaveBeenCalledTimes(0);
+      )
+    );
+    expect(remoteMock).toHaveBeenCalledTimes(0);
     await expect(browserCreator.getBrowser({})).rejects.toThrow('All parallel tests are currently in use');
-    expect(setupBrowserSpy).toHaveBeenCalledTimes(11);
+    expect(remoteMock).toHaveBeenCalledTimes(11);
   });
 
   test('should not try to reconnect if any other error than a full BrowserStack queue gets thrown', async () => {
     const browserCreator = new BrowserStackBrowserCreator(browserName, browserOptions);
-    const setupBrowserSpy = jest.spyOn(browserCreator, 'setupBrowser').mockImplementation(() => {
-      return Promise.reject(new Error('Some other error that we should accept without retrying'));
-    });
-
-    expect(setupBrowserSpy).toHaveBeenCalledTimes(0);
-    await expect(browserCreator.getBrowser({})).rejects.toThrow();
-    expect(setupBrowserSpy).toHaveBeenCalledTimes(1);
+    remoteMock.mockReturnValue(Promise.reject(new Error('Some other error that we should accept without retrying')));
+    expect(remoteMock).toHaveBeenCalledTimes(0);
+    await expect(browserCreator.getBrowser({})).rejects.toThrow(/Some other error/);
+    expect(remoteMock).toHaveBeenCalledTimes(1);
   });
 
-  test('should use BrowserStack hub url', async () => {
+  test('should propagate configuration to browser stack', async () => {
     const browserCreator = new BrowserStackBrowserCreator(browserName, browserOptions);
-    const url = await browserCreator.__getBrowserUrl();
+    const browser = await browserCreator.getBrowser({});
 
-    expect(url.hostname).toBe('hub.browserstack.com');
-  });
-
-  test('should have BrowserStack specific capabilities', async () => {
-    const browserCreator = new BrowserStackBrowserCreator(browserName, {
-      ...browserOptions,
-      projectName: 'project',
-      credentials: { user: 'my-user', key: 'my-key' },
-    });
-
-    const capabilities = browserCreator.__getCapabilities();
-    expect(capabilities['bstack:options']).toEqual(
+    expect(browser.options).toEqual(
       expect.objectContaining({
-        projectName: 'project',
-        userName: 'my-user',
-        accessKey: 'my-key',
+        capabilities: {
+          browserName: 'chrome',
+          'bstack:options': expect.objectContaining({
+            projectName: 'project',
+            userName: 'my-user',
+            accessKey: 'my-key',
+          }),
+        },
+        hostname: 'hub.browserstack.com',
+        path: '/wd/hub',
+        port: 80,
+        protocol: 'http',
       })
     );
   });

--- a/test/browsers/devicefarm-mobile.test.ts
+++ b/test/browsers/devicefarm-mobile.test.ts
@@ -1,21 +1,29 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import './wdio-mock';
 import MobileBrowserCreator from '../../src/browsers/devicefarm-mobile';
 
 const seleniumUrl = 'http://localhost:4444/wd';
 
 describe('Mobile Devicefarm browserCreator', () => {
-  test('can pass down selenium URL', async () => {
+  test('can pass down browser options', async () => {
     const browserCreator = new MobileBrowserCreator('iOS', { seleniumUrl });
 
-    const { hostname } = await browserCreator.__getBrowserUrl();
-    expect(hostname).toBe('localhost');
+    const browser = await browserCreator.getBrowser({});
+    expect(browser.options).toEqual(
+      expect.objectContaining({
+        hostname: 'localhost',
+        path: '/wd',
+        port: 4444,
+        protocol: 'http',
+      })
+    );
   });
 
-  test.each([{ platform: 'Android' }, { platform: 'iOS' }])('adds $platform capabilities', () => {
+  test.each([{ platform: 'Android' }, { platform: 'iOS' }])('adds $platform capabilities', async () => {
     const browserCreator = new MobileBrowserCreator('Android', { seleniumUrl });
 
-    const capabilities = browserCreator.__getCapabilities();
-    expect(capabilities['appium:platformName']).toBe('Android');
+    const browser = await browserCreator.getBrowser({});
+    expect((browser.options.capabilities as any)['appium:platformName']).toEqual('Android');
   });
 });

--- a/test/browsers/devicefarm-mobile.test.ts
+++ b/test/browsers/devicefarm-mobile.test.ts
@@ -1,6 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const MobileBrowserCreator = require('../../src/browsers/devicefarm-mobile').default;
+import MobileBrowserCreator from '../../src/browsers/devicefarm-mobile';
 
 const seleniumUrl = 'http://localhost:4444/wd';
 

--- a/test/browsers/devicefarm.test.ts
+++ b/test/browsers/devicefarm.test.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const { URL } = require('url');
-const DeviceFarmClientMock = require('aws-sdk/clients/devicefarm');
-const DevicefarmBrowserCreator = require('../../src/browsers/devicefarm').default;
+import { URL } from 'url';
+import DeviceFarmClientMock from 'aws-sdk/clients/devicefarm';
+import DevicefarmBrowserCreator from '../../src/browsers/devicefarm';
 const browserName = 'Chrome';
 
 describe('Devicefarm browserCreator ', () => {
@@ -35,5 +35,16 @@ describe('Devicefarm browserCreator ', () => {
     const browser = await browserCreator.__getBrowserUrl();
     expect(browser).toEqual(expect.any(URL));
     expect(DeviceFarmClientMock.prototype.createTestGridUrl).toHaveBeenCalledTimes(1);
+  });
+
+  test('should implement __getCapabilities', async () => {
+    const browserCreator = new DevicefarmBrowserCreator(browserName, {});
+
+    const capabilities = browserCreator.__getCapabilities();
+    expect(capabilities).toEqual(
+      expect.objectContaining({
+        browserName: 'chrome',
+      })
+    );
   });
 });

--- a/test/browsers/devicefarm.test.ts
+++ b/test/browsers/devicefarm.test.ts
@@ -1,8 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { URL } from 'url';
+import './wdio-mock';
 import DeviceFarmClientMock from 'aws-sdk/clients/devicefarm';
 import DevicefarmBrowserCreator from '../../src/browsers/devicefarm';
+
 const browserName = 'Chrome';
 
 describe('Devicefarm browserCreator ', () => {
@@ -12,39 +13,33 @@ describe('Devicefarm browserCreator ', () => {
 
   test('should throw if retries limit exceeded', async () => {
     const browserCreator = new DevicefarmBrowserCreator(browserName, { projectArn: 'throttling', retryCount: 1 });
-    await expect(browserCreator.__getBrowserUrl()).rejects.toThrow('ThrottlingException');
+    await expect(browserCreator.getBrowser({})).rejects.toThrow('ThrottlingException');
     expect(DeviceFarmClientMock.prototype.createTestGridUrl).toHaveBeenCalledTimes(2);
   });
 
   test('should throw if devicefarm returned an invalid response', async () => {
     const browserCreator = new DevicefarmBrowserCreator(browserName, { projectArn: 'invalid' });
-    await expect(browserCreator.__getBrowserUrl()).rejects.toThrow(
-      'Invalid response from devicefarm: {"invalid":true}'
-    );
+    await expect(browserCreator.getBrowser({})).rejects.toThrow('Invalid response from devicefarm: {"invalid":true}');
     expect(DeviceFarmClientMock.prototype.createTestGridUrl).toHaveBeenCalledTimes(1);
   });
 
   test('should throw if client returns unknown error', async () => {
     const browserCreator = new DevicefarmBrowserCreator(browserName, { projectArn: 'unknown' });
-    await expect(browserCreator.__getBrowserUrl()).rejects.toThrow('unknown error');
+    await expect(browserCreator.getBrowser({})).rejects.toThrow('unknown error');
     expect(DeviceFarmClientMock.prototype.createTestGridUrl).toHaveBeenCalledTimes(1);
   });
 
   test('should return grid url in case of success', async () => {
     const browserCreator = new DevicefarmBrowserCreator(browserName, { projectArn: 'pass' });
-    const browser = await browserCreator.__getBrowserUrl();
-    expect(browser).toEqual(expect.any(URL));
-    expect(DeviceFarmClientMock.prototype.createTestGridUrl).toHaveBeenCalledTimes(1);
-  });
-
-  test('should implement __getCapabilities', async () => {
-    const browserCreator = new DevicefarmBrowserCreator(browserName, {});
-
-    const capabilities = browserCreator.__getCapabilities();
-    expect(capabilities).toEqual(
+    const browser = await browserCreator.getBrowser({});
+    expect(browser.options).toEqual(
       expect.objectContaining({
-        browserName: 'chrome',
+        hostname: 'localhost',
+        path: '/devicefarm-test-grid',
+        port: 4444,
+        protocol: 'http',
       })
     );
+    expect(DeviceFarmClientMock.prototype.createTestGridUrl).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/browsers/wdio-mock.ts
+++ b/test/browsers/wdio-mock.ts
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import type { RemoteOptions } from 'webdriverio';
+
+class FakeWebdriver {
+  isMobile = true;
+  options: RemoteOptions;
+
+  constructor(options: RemoteOptions) {
+    this.options = options;
+  }
+
+  setTimeout() {
+    // noop
+  }
+}
+
+export const remoteMock = jest.fn();
+
+beforeEach(() => {
+  remoteMock.mockReset();
+  remoteMock.mockImplementation((options: RemoteOptions) => new FakeWebdriver(options));
+});
+
+jest.mock('webdriverio', () => ({
+  remote: remoteMock,
+}));

--- a/test/compare-images.test.ts
+++ b/test/compare-images.test.ts
@@ -5,6 +5,7 @@ import { PNG } from 'pngjs';
 import useBrowser from '../src/use-browser';
 import { ScreenshotPageObject } from '../src/page-objects';
 import { cropAndCompare, parsePng } from '../src/image-utils';
+import './utils/setup-local-driver';
 
 type TestFn = (page: ScreenshotPageObject, browser: WebdriverIO.Browser) => Promise<void>;
 

--- a/test/compare-images.test.ts
+++ b/test/compare-images.test.ts
@@ -1,12 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const fs = require('fs');
-const { PNG } = require('pngjs');
-const useBrowser = require('../src/use-browser').default;
-const { ScreenshotPageObject } = require('../src/page-objects');
-const { cropAndCompare, parsePng } = require('../src/image-utils');
+import fs from 'fs';
+import { PNG } from 'pngjs';
+import useBrowser from '../src/use-browser';
+import { ScreenshotPageObject } from '../src/page-objects';
+import { cropAndCompare, parsePng } from '../src/image-utils';
 
-function setupTest(testFn) {
+type TestFn = (page: ScreenshotPageObject, browser: WebdriverIO.Browser) => Promise<void>;
+
+function setupTest(testFn: TestFn) {
   return useBrowser(async browser => {
     const page = new ScreenshotPageObject(browser);
     await browser.url('./compare-test.html');
@@ -132,7 +134,7 @@ test(
     expect(height).toBe(51); // Defined in CSS as 50.666
 
     // Write images to do manual assessment
-    fs.writeFileSync('build/screenshots/rounding-diff.png', result.diffImage);
+    fs.writeFileSync('build/screenshots/rounding-diff.png', result.diffImage!);
   })
 );
 
@@ -164,7 +166,7 @@ test(
     // Write images to do manual assessment
     fs.writeFileSync('build/screenshots/first.png', result.firstImage);
     fs.writeFileSync('build/screenshots/second.png', result.secondImage);
-    fs.writeFileSync('build/screenshots/diff.png', result.diffImage);
+    fs.writeFileSync('build/screenshots/diff.png', result.diffImage!);
   })
 );
 
@@ -183,7 +185,7 @@ test('should work with higher device pixel ratios', async () => {
     { image: blue, pixelRatio: 2, offset, width, height }
   );
 
-  fs.writeFileSync('build/screenshots/diff.png', diffImage);
+  fs.writeFileSync('build/screenshots/diff.png', diffImage!);
 
   expect(diffPixels).not.toBe(0);
 });
@@ -198,8 +200,8 @@ test('detects identical images with higher device pixel ratios', async () => {
     height: 150,
   };
   const { diffPixels } = await cropAndCompare(
-    { image: img, pixelRatio: 2, offset },
-    { image: img, pixelRatio: 2, offset }
+    { image: img, pixelRatio: 2, offset, width: img.width, height: img.height },
+    { image: img, pixelRatio: 2, offset, width: img.width, height: img.height }
   );
 
   expect(diffPixels).toBe(0);

--- a/test/full-page-screenshot.test.ts
+++ b/test/full-page-screenshot.test.ts
@@ -6,6 +6,7 @@ import { parsePng, packPng } from '../src/image-utils/utils';
 import { compareImages } from '../src/image-utils/compare';
 import useBrowser from '../src/use-browser';
 import { scrollAndMergeStrategy, puppeteerStrategy } from '../src/page-objects/full-page-screenshot';
+import './utils/setup-local-driver';
 
 type TestFn = (browser: WebdriverIO.Browser) => Promise<void>;
 function setupTest(testFn: TestFn) {

--- a/test/full-page-screenshot.test.ts
+++ b/test/full-page-screenshot.test.ts
@@ -1,11 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const { parsePng, packPng } = require('../src/image-utils/utils');
-const { compareImages } = require('../src/image-utils/compare');
-const useBrowser = require('../src/use-browser').default;
-const { scrollAndMergeStrategy, puppeteerStrategy } = require('../src/page-objects/full-page-screenshot');
+import type { Browser as PuppeteerBrowser } from 'puppeteer-core';
 
-function setupTest(testFn) {
+import { parsePng, packPng } from '../src/image-utils/utils';
+import { compareImages } from '../src/image-utils/compare';
+import useBrowser from '../src/use-browser';
+import { scrollAndMergeStrategy, puppeteerStrategy } from '../src/page-objects/full-page-screenshot';
+
+type TestFn = (browser: WebdriverIO.Browser) => Promise<void>;
+function setupTest(testFn: TestFn) {
   return useBrowser(async browser => {
     await browser.url('/test-full-page-screenshot.html');
     await testFn(browser);
@@ -17,7 +20,7 @@ test(
   setupTest(async browser => {
     const puppeteer = await browser.getPuppeteer();
 
-    const expected = await parsePng(await puppeteerStrategy(browser, puppeteer));
+    const expected = await parsePng(await puppeteerStrategy(browser, puppeteer as unknown as PuppeteerBrowser));
     const actual = await parsePng(await scrollAndMergeStrategy(browser));
     const diff = compareImages(expected, actual, { width: expected.width, height: expected.height });
 
@@ -33,7 +36,7 @@ test.skip(
     const toggle = await browser.$('#multiple-pages-toggle');
     await toggle.click();
 
-    const puppeteerImage = await puppeteerStrategy(browser, puppeteer);
+    const puppeteerImage = await puppeteerStrategy(browser, puppeteer as unknown as PuppeteerBrowser);
     const scrollAndMergeImage = await scrollAndMergeStrategy(browser);
     const expected = await parsePng(puppeteerImage);
     const actual = await parsePng(scrollAndMergeImage);

--- a/test/image-utils.test.ts
+++ b/test/image-utils.test.ts
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const fs = require('fs');
-const path = require('path');
-const mergeImages = require('../src/image-utils/merge').default;
-const { parsePng } = require('../src/image-utils');
+import fs from 'fs';
+import path from 'path';
+import mergeImages from '../src/image-utils/merge';
+import { parsePng } from '../src/image-utils';
 
 describe('mergeImages', () => {
   test('should not merge images beyond their dimensions', async () => {

--- a/test/page-object.test.ts
+++ b/test/page-object.test.ts
@@ -3,6 +3,7 @@
 import { ScreenshotPageObject } from '../src/page-objects';
 import { calculateIosTopOffset } from '../src/page-objects/utils';
 import useBrowser from '../src/use-browser';
+import './utils/setup-local-driver';
 
 type TestFn = (page: ScreenshotPageObject) => Promise<void>;
 function setupTest(testFn: TestFn) {
@@ -97,7 +98,7 @@ test(
   'setWindowSize',
   setupTest(async page => {
     await page.setWindowSize({ width: 400, height: 300 });
-    expect(await page.getBrowser().getWindowSize()).toEqual({ width: 400, height: 300 });
+    expect(await page.getViewportSize()).toEqual(expect.objectContaining({ width: 400, height: 300 }));
   })
 );
 

--- a/test/page-object.test.ts
+++ b/test/page-object.test.ts
@@ -1,10 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const { ScreenshotPageObject } = require('../src/page-objects');
-const { calculateIosTopOffset } = require('../src/page-objects/utils');
-const useBrowser = require('../src/use-browser').default;
+import { ScreenshotPageObject } from '../src/page-objects';
+import { calculateIosTopOffset } from '../src/page-objects/utils';
+import useBrowser from '../src/use-browser';
 
-function setupTest(testFn) {
+type TestFn = (page: ScreenshotPageObject) => Promise<void>;
+function setupTest(testFn: TestFn) {
   return useBrowser(async browser => {
     await browser.url('./test-page-object.html');
     await testFn(new ScreenshotPageObject(browser));
@@ -96,7 +97,7 @@ test(
   'setWindowSize',
   setupTest(async page => {
     await page.setWindowSize({ width: 400, height: 300 });
-    expect(await page.browser.getWindowSize()).toEqual({ width: 400, height: 300 });
+    expect(await page.getBrowser().getWindowSize()).toEqual({ width: 400, height: 300 });
   })
 );
 
@@ -129,7 +130,7 @@ describe('waitForAssertion', () => {
   test(
     'successful assertion',
     setupTest(async page => {
-      const assertion = jest.fn(() => expect(true).toEqual(true));
+      const assertion = jest.fn(async () => expect(true).toEqual(true));
       await page.waitForAssertion(assertion);
       expect(assertion).toHaveBeenCalledTimes(1);
     })
@@ -139,7 +140,7 @@ describe('waitForAssertion', () => {
     'retrying once assertion',
     setupTest(async page => {
       let counter = 0;
-      const assertion = jest.fn(() => {
+      const assertion = jest.fn(async () => {
         counter++;
         expect(counter).toEqual(2);
       });
@@ -151,7 +152,7 @@ describe('waitForAssertion', () => {
   test(
     'reports the original error into the outer scope',
     setupTest(async page => {
-      const assertion = jest.fn(() => expect(true).toEqual(false));
+      const assertion = jest.fn(async () => expect(true).toEqual(false));
       await expect(page.waitForAssertion(assertion)).rejects.toThrowError(/toEqual/);
       expect(assertion).toHaveBeenCalledTimes(6);
     })
@@ -231,7 +232,7 @@ test(
   setupTest(async page => {
     const height = 250;
     await page.setWindowSize({ width: 300, height });
-    const scrollHeight = await page.getElementProperty('body', 'scrollHeight');
+    const scrollHeight = (await page.getElementProperty('body', 'scrollHeight')) as number;
 
     await page.scrollToBottom('body');
 

--- a/test/use-browser.test.ts
+++ b/test/use-browser.test.ts
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const { promisify } = require('util');
-const useBrowser = require('../src/use-browser').default;
-const { configure } = require('../src/use-browser');
-const { getViewportSize } = require('../src/browser-scripts');
+import { promisify } from 'util';
+import useBrowser from '../src/use-browser';
+import { configure } from '../src/use-browser';
+import { getViewportSize } from '../src/browser-scripts';
+
 const delay = promisify(setTimeout);
 
 test(
@@ -27,7 +28,8 @@ test(
 test('should close browser after test finish', async () => {
   const onDeleteSession = jest.fn();
   await useBrowser(async browser => {
-    browser.overwriteCommand('deleteSession', async originalCommand => {
+    // FIXME: Casting to any isn't ideal, but it's the only way to overwrite this command
+    (browser as any).overwriteCommand('deleteSession', async (originalCommand: any) => {
       await originalCommand();
       onDeleteSession();
     });
@@ -91,7 +93,12 @@ test('should run multiple browsers in parallel', () => {
     await browser.url('./index.html');
     await browser.pause(400);
   });
-  const threadWithDelay = () => delay(200).then(() => useBrowser(browser => browser.url('./index.html'))());
+  const threadWithDelay = () =>
+    delay(200).then(() =>
+      useBrowser(browser => {
+        browser.url('./index.html');
+      })()
+    );
 
   return Promise.all([threadOne(), threadTwo(), threadThree(), threadWithDelay()]);
 });

--- a/test/use-browser.test.ts
+++ b/test/use-browser.test.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util';
 import useBrowser from '../src/use-browser';
 import { configure } from '../src/use-browser';
 import { getViewportSize } from '../src/browser-scripts';
+import './utils/setup-local-driver';
 
 const delay = promisify(setTimeout);
 

--- a/test/utils/config.ts
+++ b/test/utils/config.ts
@@ -1,5 +1,3 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-module.exports = {
-  chromeDriverPort: '9515',
-};
+export const chromeDriverPort = '9515';

--- a/test/utils/setup-local-driver.ts
+++ b/test/utils/setup-local-driver.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const { configure } = require('../../src/use-browser');
-const { chromeDriverPort } = require('./config');
+import { chromeDriverPort } from './config';
+import { configure } from '../../src/use-browser';
 
 jest.setTimeout(80 * 1000);
 

--- a/test/utils/start-chromedriver.ts
+++ b/test/utils/start-chromedriver.ts
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const { startWebdriver } = require('../../dist/chrome-launcher');
-const { chromeDriverPort } = require('./config');
+import { startWebdriver } from '../../dist/chrome-launcher';
+import { chromeDriverPort } from './config';
 
-module.exports = async () => {
+export default async () => {
   await startWebdriver(chromeDriverPort);
 };

--- a/test/utils/stop-chromedriver.ts
+++ b/test/utils/stop-chromedriver.ts
@@ -1,5 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-const { shutdownWebdriver } = require('../../dist/chrome-launcher');
+import { shutdownWebdriver } from '../../dist/chrome-launcher';
 
-module.exports = shutdownWebdriver;
+export default shutdownWebdriver;

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["test"]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Rename all tests to .ts
- Removed protected from internal methods so they are accessible from the tests
- Typescript fixes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
