### PR TITLE
chore: Revert: Make sure the iOS Safari tab bar is always at the bottom

### DIFF
--- a/src/browsers/browser-creator.ts
+++ b/src/browsers/browser-creator.ts
@@ -54,9 +54,6 @@ export default abstract class BrowserCreator {
     if (!browser.isMobile) {
       await browser.$('body').then(body => body.moveTo({ xOffset: 0, yOffset: 0 }));
       await browser.setWindowSize(options.width, options.height);
-    } else if (browser.isIOS) {
-      // Make sure the tab bar is always at the bottom to ensure screenshots are taken properly
-      browser.updateSettings({ safariTabBarPosition: 'bottom' });
     }
 
     return browser;

--- a/test/browsers/devicefarm-mobile.test.ts
+++ b/test/browsers/devicefarm-mobile.test.ts
@@ -20,16 +20,10 @@ describe('Mobile Devicefarm browserCreator', () => {
     );
   });
 
-  test.each([{ platform: 'Android' }, { platform: 'iOS' }])('adds $platform capabilities', async ({ platform }) => {
-    const browserCreator = new MobileBrowserCreator(platform, { seleniumUrl });
+  test.each([{ platform: 'Android' }, { platform: 'iOS' }])('adds $platform capabilities', async () => {
+    const browserCreator = new MobileBrowserCreator('Android', { seleniumUrl });
 
     const browser = await browserCreator.getBrowser({});
-    expect((browser.options.capabilities as any)['appium:platformName']).toEqual(platform);
-
-    if (platform === 'Android') {
-      expect(browser.updateSettings).not.toBeCalled();
-    } else {
-      expect(browser.updateSettings).toBeCalledWith({ safariTabBarPosition: 'bottom' });
-    }
+    expect((browser.options.capabilities as any)['appium:platformName']).toEqual('Android');
   });
 });

--- a/test/browsers/wdio-mock.ts
+++ b/test/browsers/wdio-mock.ts
@@ -13,12 +13,6 @@ class FakeWebdriver {
   setTimeout() {
     // noop
   }
-
-  get isIOS() {
-    return (this.options.capabilities as any)['appium:platformName'] === 'iOS';
-  }
-
-  updateSettings = jest.fn();
 }
 
 export const remoteMock = jest.fn();


### PR DESCRIPTION
Reverts cloudscape-design/browser-test-tools#57.

The API doesn't actually do what we thought it did :( 