### PR TITLE
fix: add missing browsers to local run configuration

### DIFF
--- a/src/browsers/local.ts
+++ b/src/browsers/local.ts
@@ -5,6 +5,7 @@ import BrowserCreator from './browser-creator';
 import defaultCapabilities, { Capabilities, getCapability, mergeCapabilities } from './capabilities';
 
 const localBrowsers: Record<string, Capabilities> = {
+  ...defaultCapabilities,
   ChromeHeadless: mergeCapabilities(defaultCapabilities.ChromeHeadless, {
     'goog:chromeOptions': {
       // do not use retina screen when testing locally


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It got accidentally removed there https://github.com/cloudscape-design/browser-test-tools/commit/b0610161ec99fd2eb50ba125740e3133ae719a5c#diff-94fbee9f84ac61415e3ab21504c0d7e598384a284f3b86acb41128a6f0b21c89L9, let's bring this back


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
