### PR TITLE
chore: fix extension between ChromeHeadless and ChromeHeadlessIntegration browser variants

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   release:
-    uses: cloudscape-design/actions/.github/workflows/release.yml@main
+    uses: cloudscape-design/actions/.github/workflows/release.yml@release-artifacts
     secrets: inherit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`ChromeHeadlessIntegration`  should extend `local.ChromeHeadless` and not `default.ChromeHeadless`.

Thic change makes sure that disabling retina mode (`mobileEmulation` prop) applies  consistently on all variants


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
