### PR TITLE
fix: Fix localhost address resolution in NodeJS 17+

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pretest": "npm run clean && npm run build",
     "test": "run-p -r start-http-server run-tests",
     "run-tests": "wait-on http://localhost:9615 && jest",
-    "start-http-server": "http-server test/fixtures --port=9615 --silent",
+    "start-http-server": "http-server test/fixtures --port=9615 -a localhost --silent",
     "lint": "eslint --ext=ts,js --ignore-path .gitignore .",
     "build": "./scripts/generate-exports.js && tsc",
     "prepublishOnly": "npm run build",

--- a/src/page-objects/utils.ts
+++ b/src/page-objects/utils.ts
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import dns from 'dns';
 import { WebdriverIoUnsupportedPuppeteerErrorText, WebdriverIoRemotePuppeteerErrorText } from '../exceptions';
 import { ViewportSize, ElementRect } from './types';
 
@@ -63,6 +64,9 @@ export function calculateIosTopOffset(
 }
 
 export async function getPuppeteer(browser: WebdriverIO.Browser) {
+  // Make sure to favor IPv4 name resolution over IPv6 so that the localhost debugger can be found.
+  dns.setDefaultResultOrder('ipv4first');
+
   try {
     const puppeteer = await browser.getPuppeteer();
     return puppeteer;

--- a/test/utils/start-chromedriver.ts
+++ b/test/utils/start-chromedriver.ts
@@ -1,8 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import dns from 'dns';
 import { startWebdriver } from '../../dist/chrome-launcher';
 import { chromeDriverPort } from './config';
 
 export default async () => {
+  // Make sure to favor IPv4 name resolution over IPv6 so that the localhost debugger can be found.
+  dns.setDefaultResultOrder('ipv4first');
+
   await startWebdriver(chromeDriverPort);
 };


### PR DESCRIPTION
*Issue #, if available:* AWSUI-22318

*Description of changes:* Starting with NodeJS 17, the default DNS name resolution now favors IPv6 over IPv4 addresses. This means that "localhost" now resolves to `::1` instead of `127.0.0.1`. This causes some compatibility issues with the local dev server, as well as the local Chrome/puppeteer debugger address.

This PR changes the algorithm back to favor IPv4 addresses.

See this green Draft PR using NodeJS 18 in all GitHub workflows: https://github.com/cloudscape-design/browser-test-tools/pull/66.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
