### PR TITLE
chore: Fix full page screenshot test issue

### DIFF
--- a/test/full-page-screenshot.test.ts
+++ b/test/full-page-screenshot.test.ts
@@ -6,6 +6,7 @@ import { parsePng, packPng } from '../src/image-utils/utils';
 import { compareImages } from '../src/image-utils/compare';
 import useBrowser from '../src/use-browser';
 import { scrollAndMergeStrategy, puppeteerStrategy } from '../src/page-objects/full-page-screenshot';
+import { getPuppeteer } from '../src/page-objects/utils';
 import './utils/setup-local-driver';
 
 type TestFn = (browser: WebdriverIO.Browser) => Promise<void>;
@@ -19,7 +20,7 @@ function setupTest(testFn: TestFn) {
 test(
   'scrollAndMergeStrategy and puppeteerStrategy produce same for single page',
   setupTest(async browser => {
-    const puppeteer = await browser.getPuppeteer();
+    const puppeteer = await getPuppeteer(browser);
 
     const expected = await parsePng(await puppeteerStrategy(browser, puppeteer as unknown as PuppeteerBrowser));
     const actual = await parsePng(await scrollAndMergeStrategy(browser));
@@ -32,7 +33,7 @@ test(
 test.skip(
   'scrollAndMergeStrategy and puppeteerStrategy produce same for multiple pages',
   setupTest(async browser => {
-    const puppeteer = await browser.getPuppeteer();
+    const puppeteer = await getPuppeteer(browser);
 
     const toggle = await browser.$('#multiple-pages-toggle');
     await toggle.click();


### PR DESCRIPTION
*Issue #, if available:*

Fixing this issue: https://github.com/cloudscape-design/components/actions/runs/6868817322/attempts/9

*Description of changes:*

There is a compatibility between webdriverio v7 and node.js 18: https://github.com/webdriverio/webdriverio/issues/8279 (we should upgrade to v8, really).

We already applied a workaround: https://github.com/cloudscape-design/browser-test-tools/pull/67 However it was not covering this test, because we called `browser.getPuppeteer` directly. Swapping with a utility makes it more stable (I think)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
