### PR TITLE
chore: Increase test timeout

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     environment: 'node',
     globalSetup: './test/utils/global-setup.ts',
-    testTimeout: 15000,
+    testTimeout: 60000,
     poolOptions: {
       threads: {
         minThreads: 1,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Fix [this build issue](https://github.com/cloudscape-design/components/actions/runs/9684655320/job/26722947216?pr=2419). We already have 60 seconds config on all our other repositories, let's follow the suite here too
* Rename the config file to address this deprecation warning: "The CJS build of Vite's Node API is deprecated"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
