### PR TITLE
chore: Add an optional parameter to bypass puppeteer

### DIFF
--- a/src/page-objects/full-page-screenshot.ts
+++ b/src/page-objects/full-page-screenshot.ts
@@ -51,9 +51,9 @@ export async function scrollAndMergeStrategy(browser: WebdriverIO.Browser) {
   return mergeImages(screenshots, width * pixelRatio, height * pixelRatio, lastImageOffset * pixelRatio, offsetTop);
 }
 
-export default async function fullPageScreenshot(browser: WebdriverIO.Browser) {
+export default async function fullPageScreenshot(browser: WebdriverIO.Browser, forceScrollAndMerge: boolean = false) {
   const puppeteer = await getPuppeteer(browser);
-  if (puppeteer) {
+  if (puppeteer && !forceScrollAndMerge) {
     // casting due to mismatch in NodeJS types of EventEmitter
     return puppeteerStrategy(browser, puppeteer as unknown as PuppeteerBrowser);
   }

--- a/src/page-objects/screenshot.ts
+++ b/src/page-objects/screenshot.ts
@@ -7,6 +7,10 @@ import { ElementOffset, ScreenshotCapturingOptions, ScreenshotWithOffset } from 
 import fullPageScreenshot from './full-page-screenshot';
 
 export default class ScreenshotPageObject extends BasePageObject {
+  constructor(browser: WebdriverIO.Browser, public readonly forceScrollAndMerge: boolean = false) {
+    super(browser);
+  }
+
   async focusNextElement() {
     return this.keys('Tab');
   }
@@ -24,7 +28,7 @@ export default class ScreenshotPageObject extends BasePageObject {
     const scrollPosition = await this.getWindowScroll();
     // Wait for the page to settle before taking a screenshot
     await this.waitForJsTimers();
-    const screenshot = await fullPageScreenshot(this.browser);
+    const screenshot = await fullPageScreenshot(this.browser, this.forceScrollAndMerge);
     // restore scroll position
     await this.windowScrollTo(scrollPosition);
     return screenshot;


### PR DESCRIPTION
This pull request adds an optional parameter to forcibly bypass puppeteer and use the `scollAndMergeStrategy` to perform screenshot tests. This was added to support the conditional use of `scollAndMergeStrategy` when taking RTL screenshots in Chrome.