### PR TITLE
fix: Use https to access browserstack

### DIFF
--- a/src/browsers/browserstack.ts
+++ b/src/browsers/browserstack.ts
@@ -8,7 +8,7 @@ import { Capabilities, getCapability } from './capabilities';
 
 const N_SEC_SLEEP_BEFORE_RETRY = 30;
 
-const browserStackHub = 'http://hub.browserstack.com:80/wd/hub';
+const browserStackHub = 'https://hub.browserstack.com/wd/hub';
 
 const browsers: Record<string, Capabilities> = {
   Firefox: {

--- a/test/browsers/browserstack.test.ts
+++ b/test/browsers/browserstack.test.ts
@@ -58,8 +58,8 @@ describe('BrowserStack browserCreator ', () => {
         },
         hostname: 'hub.browserstack.com',
         path: '/wd/hub',
-        port: 80,
-        protocol: 'http',
+        port: 443,
+        protocol: 'https',
       })
     );
   });


### PR DESCRIPTION
*Issue #, if available:*

## Notes

Self-explanatory. Use https, because it is better

## Testing

Deployed to my dev-pipeline and got a green browserstack test run


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
