### PR TITLE
fix: Temporarily set chrome headless mode to old

### DIFF
--- a/src/browsers/capabilities.ts
+++ b/src/browsers/capabilities.ts
@@ -56,7 +56,7 @@ const defaultCapabilities: Record<string, Capabilities> = {
         '--prerender-from-omnibox=disabled',
         '--no-sandbox',
         '--disable-gpu',
-        '--headless',
+        '--headless=old',
       ],
     },
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* New version of chrome set headless to "new" which caused problems in tests. Temporarily, setting it to "old" to unblock tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
