### PR TITLE
fix: Adjust viewport height for Firefox

### DIFF
--- a/src/browsers/browser-creator.ts
+++ b/src/browsers/browser-creator.ts
@@ -5,6 +5,7 @@ import merge from 'lodash/merge';
 
 import { BrowserError } from '../exceptions';
 import { Capabilities } from './capabilities';
+import { addFirefoxOffset } from './utils';
 
 export interface WebDriverOptions {
   width: number;
@@ -52,8 +53,14 @@ export default abstract class BrowserCreator {
     await browser.setTimeout({ implicit: options.implicitTimeout, script: options.scriptTimeout });
 
     if (!browser.isMobile) {
+      let adjustedSizeOptions = options;
+
       await browser.$('body').then(body => body.moveTo({ xOffset: 0, yOffset: 0 }));
-      await browser.setWindowSize(options.width, options.height);
+
+      if (browser.isFirefox) {
+        adjustedSizeOptions = addFirefoxOffset(options);
+      }
+      await browser.setWindowSize(adjustedSizeOptions.width, adjustedSizeOptions.height);
     }
 
     return browser;

--- a/src/browsers/utils.ts
+++ b/src/browsers/utils.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { WebDriverOptions } from './browser-creator';
+
+// with the release of Firefox 129 the viewport got smaller, which affects tests
+// we adjust the default height to mitigate the issue
+// todo: check if still needed after migration to webdriverio v9
+export const FIREFOX_VIEWPORT_OFFSET = 134;
+
+export const addFirefoxOffset = (options: WebDriverOptions): WebDriverOptions => {
+  const updatedHeight = options.height + FIREFOX_VIEWPORT_OFFSET;
+  return {
+    ...options,
+    height: updatedHeight,
+  };
+};

--- a/src/page-objects/base.ts
+++ b/src/page-objects/base.ts
@@ -14,6 +14,7 @@ import {
 import EventsSpy from './events-spy';
 import * as liveAnnouncements from '../browser-scripts/live-announcements';
 import { getElementCenter } from './utils';
+import { FIREFOX_VIEWPORT_OFFSET } from '../browsers/utils';
 
 import { ElementRect } from './types';
 import { waitForTimerAndAnimationFrame } from './browser-scripts';
@@ -30,7 +31,8 @@ export default class BasePageObject {
   }
 
   async setWindowSize({ width, height }: { width: number; height: number }) {
-    await this.browser.setWindowSize(width, height);
+    const adjustedHeight = this.browser.isFirefox ? height + FIREFOX_VIEWPORT_OFFSET : height;
+    await this.browser.setWindowSize(width, adjustedHeight);
   }
 
   async spyOnEvents(selector: string, events: string[]) {


### PR DESCRIPTION
*Issue #, if available:* AWSUI-54809

*Description of changes:*
The version of Firefox (129) has significantly smaller viewport size. It's consistently shorter for 134px, this difference comes potentially from the topbar. To compensate for that, we add the same amount of pixels back to the height.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
