### PR TITLE
chore: Use chromium headless=new mode

### DIFF
--- a/src/browsers/capabilities.ts
+++ b/src/browsers/capabilities.ts
@@ -56,7 +56,7 @@ const defaultCapabilities: Record<string, Capabilities> = {
         '--prerender-from-omnibox=disabled',
         '--no-sandbox',
         '--disable-gpu',
-        '--headless=old',
+        '--headless=new',
       ],
     },
   },

--- a/test/page-object.test.ts
+++ b/test/page-object.test.ts
@@ -94,12 +94,19 @@ test(
   })
 );
 
-test(
-  'setWindowSize',
+test.each([
+  { width: 400, height: 300 },
+  { width: 400, height: 300 },
+])('setWindowSize, width=$width, height=$height', size =>
   setupTest(async page => {
-    await page.setWindowSize({ width: 400, height: 300 });
-    expect(await page.getViewportSize()).toEqual(expect.objectContaining({ width: 400, height: 300 }));
-  })
+    await page.setWindowSize(size);
+    const { width, height } = await page.getViewportSize();
+    expect(width).toBe(size.width);
+
+    // With Chromium --headless=new the window.innerHeight differs from the defined window height.
+    expect(height).toBeGreaterThan(size.height - 100);
+    expect(height).toBeLessThanOrEqual(size.height);
+  })()
 );
 
 test(

--- a/test/page-object.test.ts
+++ b/test/page-object.test.ts
@@ -96,7 +96,7 @@ test(
 
 test.each([
   { width: 400, height: 300 },
-  { width: 400, height: 300 },
+  { width: 300, height: 400 },
 ])('setWindowSize, width=$width, height=$height', size =>
   setupTest(async page => {
     await page.setWindowSize(size);

--- a/test/use-browser.test.ts
+++ b/test/use-browser.test.ts
@@ -18,13 +18,20 @@ test(
   })
 );
 
-test(
-  'should allow to override browser options',
-  useBrowser({ width: 600, height: 400 }, async browser => {
+test.each([
+  { width: 600, height: 400 },
+  { width: 400, height: 600 },
+  { width: 1900, height: 1200 },
+])('should allow to override browser options, width=$width, height=$height', size =>
+  useBrowser(size, async browser => {
     await browser.url('./index.html');
     const { width, height } = await browser.execute(getViewportSize);
-    expect({ width, height }).toEqual({ width: 600, height: 400 });
-  })
+    expect(width).toBe(size.width);
+
+    // With Chromium --headless=new the window.innerHeight differs from the defined window height.
+    expect(height).toBeGreaterThan(size.height - 100);
+    expect(height).toBeLessThanOrEqual(size.height);
+  })()
 );
 
 test('should close browser after test finish', async () => {


### PR DESCRIPTION
Migrating to Chromium new headless mode: https://developer.chrome.com/docs/chromium/headless

There are two observer side effects:
* The window.innerHeight is smaller than the height set with useBrowser or setWindowSize setting by 87px. The problem might be solved if migrating to the newer WebdriverIO. For now, the tests are updated to tolerate the height setting as a range.
* When there is a missing favicon on the test page or it cannot be downloaded, the new Chromium adds an error to the console. These errors are then ignored as non-severe as otherwise any error in the console log makes the test fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
