### PR TITLE
feat: Change default browser height from 604px to 800px

### DIFF
--- a/src/browsers/browser-creator.ts
+++ b/src/browsers/browser-creator.ts
@@ -19,7 +19,7 @@ export interface WebDriverOptions {
 
 const defaultOptions: WebDriverOptions = {
   width: 1200,
-  height: 604,
+  height: 800,
   needsKeyboard: false,
   implicitTimeout: 5000,
   scriptTimeout: 30000,

--- a/test/browsers/browserstack.test.ts
+++ b/test/browsers/browserstack.test.ts
@@ -7,7 +7,7 @@ import BrowserStackBrowserCreator from '../../src/browsers/browserstack';
 const browserName = 'Chrome';
 const browserOptions = {
   width: 1200,
-  height: 604,
+  height: 800,
   needsKeyboard: false,
   implicitTimeout: 100,
   nSecSleepBeforeRetry: 0.001,


### PR DESCRIPTION
Changing default browser height to a bigger value to make issues with element out of screen less likely.

This is especially helpful when migrating to Chromium --headless=new because it makes window inner height smaller than the given browser height setting, see: https://github.com/cloudscape-design/browser-test-tools/pull/105.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
