### PR TITLE
fix: Enforces webdriver classic in Firefox

### DIFF
--- a/src/browsers/local.ts
+++ b/src/browsers/local.ts
@@ -27,6 +27,7 @@ const localBrowsers: Record<string, WebdriverIO.Capabilities> = {
   }),
   Firefox: mergeCapabilities(defaultCapabilities.Firefox, {
     'moz:debuggerAddress': true,
+    'wdio:enforceWebDriverClassic': true,
   }),
 };
 

--- a/src/browsers/local.ts
+++ b/src/browsers/local.ts
@@ -16,6 +16,7 @@ const localBrowsers: Record<string, WebdriverIO.Capabilities> = {
       },
     },
     // Workaround for https://github.com/webdriverio/webdriverio/issues/13440
+    // Reference: https://webdriver.io/blog/2024/08/15/webdriverio-v9-release/#new-features
     'wdio:enforceWebDriverClassic': true,
   }),
   ChromeHeadlessIntegration: mergeCapabilities(defaultCapabilities.ChromeHeadless, {
@@ -23,10 +24,13 @@ const localBrowsers: Record<string, WebdriverIO.Capabilities> = {
       args: ['--force-prefers-reduced-motion'],
     },
     // Workaround for https://github.com/webdriverio/webdriverio/issues/13440
+    // Reference: https://webdriver.io/blog/2024/08/15/webdriverio-v9-release/#new-features
     'wdio:enforceWebDriverClassic': true,
   }),
   Firefox: mergeCapabilities(defaultCapabilities.Firefox, {
     'moz:debuggerAddress': true,
+    // Workaround for failing internal tests
+    // Reference: https://webdriver.io/blog/2024/08/15/webdriverio-v9-release/#new-features
     'wdio:enforceWebDriverClassic': true,
   }),
 };


### PR DESCRIPTION
Fixes the error in internal tests: `Error: WebDriver Bidi command "browsingContext.navigate" failed with error: unknown error - Error: NS_BINDING_ABORTED`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
