### PR TITLE
chore: Upgrade Safari to version 16

### DIFF
--- a/src/browsers/browserstack.ts
+++ b/src/browsers/browserstack.ts
@@ -33,11 +33,11 @@ const browsers: Record<string, WebdriverIO.Capabilities> = {
   },
   Safari: {
     browserName: 'safari',
-    browserVersion: '15.3',
+    browserVersion: '16.5',
     'bstack:options': {
       seleniumVersion: '3.141.59',
       os: 'OS X',
-      osVersion: 'Monterey',
+      osVersion: 'Ventura',
     },
   },
   IE11: {


### PR DESCRIPTION
Since Safari 18 is out, 16 is now our oldest officially supported version.

Ticket: `AWSUI-60431`

Tested in my pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
