### PR TITLE
revert: Revert "chore: Upgrade Safari to version 16"

### DIFF
--- a/src/browsers/browserstack.ts
+++ b/src/browsers/browserstack.ts
@@ -33,11 +33,11 @@ const browsers: Record<string, WebdriverIO.Capabilities> = {
   },
   Safari: {
     browserName: 'safari',
-    browserVersion: '16.5',
+    browserVersion: '15.3',
     'bstack:options': {
       seleniumVersion: '3.141.59',
       os: 'OS X',
-      osVersion: 'Ventura',
+      osVersion: 'Monterey',
     },
   },
   IE11: {


### PR DESCRIPTION
Reverts cloudscape-design/browser-test-tools#135

There are some unexpected failures in the pipeline. Let's revert to unblock it and investigate.