### PR TITLE
chore: Upgrade Safari to version 16

### DIFF
--- a/src/browsers/browserstack.ts
+++ b/src/browsers/browserstack.ts
@@ -33,11 +33,11 @@ const browsers: Record<string, WebdriverIO.Capabilities> = {
   },
   Safari: {
     browserName: 'safari',
-    browserVersion: '15.3',
+    browserVersion: '16.5',
     'bstack:options': {
       seleniumVersion: '3.141.59',
       os: 'OS X',
-      osVersion: 'Monterey',
+      osVersion: 'Ventura',
     },
   },
   IE11: {


### PR DESCRIPTION
Reverts cloudscape-design/browser-test-tools#137

Reapply Safari upgrade after the root cause of the failures has been fixed (see https://github.com/cloudscape-design/components/pull/3363 and `CR-185585560`).

Related issue: `AWSUI-60431`

Successfully tested in my pipeline.