### PR TITLE
feat: make connectionRetryTimeout configurable

### DIFF
--- a/src/browsers/browser-creator.ts
+++ b/src/browsers/browser-creator.ts
@@ -13,6 +13,7 @@ export interface WebDriverOptions {
   needsKeyboard: boolean;
   implicitTimeout: number;
   scriptTimeout: number;
+  connectionRetryTimeout: number;
   baseUrl?: string;
   logLevel: Options.WebDriverLogTypes;
   capabilities?: Record<string, any>;
@@ -24,6 +25,8 @@ const defaultOptions: WebDriverOptions = {
   needsKeyboard: false,
   implicitTimeout: 5000,
   scriptTimeout: 30000,
+  // iOS devices can take 2-3 minutes to boot
+  connectionRetryTimeout: 240_000,
   logLevel: 'error',
 };
 
@@ -39,8 +42,7 @@ export default abstract class BrowserCreator {
     const browser = await remote({
       logLevel: options.logLevel,
       baseUrl: options.baseUrl,
-      // iOS devices can take 2-3 minutes to boot
-      connectionRetryTimeout: 240_000,
+      connectionRetryTimeout: options.connectionRetryTimeout,
       connectionRetryCount: 3,
       waitforTimeout: 5000,
       capabilities: desiredCapabilities,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The current value of 4 minutes wait time is unreasonable, because we have the total test timeout of 1 min in most places, like here for example: https://github.com/cloudscape-design/components/blob/1efbf47ce37330f36174b0ccecce8aa40e8f20a6/jest.integ.config.js#L18

The first step is to make it configurable, then apply custom very long configuration only to the use-case where it is really needed and then update the default to something more useful.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
