### PR TITLE
fix: Force reduced motion in firefox

### DIFF
--- a/src/browsers/capabilities.ts
+++ b/src/browsers/capabilities.ts
@@ -62,6 +62,7 @@ const defaultCapabilities: Record<string, WebdriverIO.Capabilities> = {
     'moz:firefoxOptions': {
       args: ['-headless'],
       prefs: {
+        'ui.prefersReducedMotion': 1,
         'fission.webContentIsolationStrategy': 0,
         'fission.bfcacheInParent': false,
       },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Same as [we already do in Chrome](https://github.com/cloudscape-design/browser-test-tools/blob/de858df44f215037873f56af5d05d723c8093f0d/src/browsers/local.ts#L24) but for Firefox.

Tested locally, with this code

```js
import useBrowser from './lib/use-browser.js';

useBrowser.configure({
  browserName: 'Firefox',
  browserCreatorOptions: {
    seleniumUrl: 'http://localhost:4444',
  },
});

await useBrowser.default(async browser => {
  const result = await browser.execute(() => {
    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
  });
  console.log(result);
})();
```

Before: prints `false`
After: prints `true`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
