### PR TITLE
fix: Take permutations screenshot before restoring window height

### DIFF
--- a/src/page-objects/screenshot.ts
+++ b/src/page-objects/screenshot.ts
@@ -84,15 +84,15 @@ export default class ScreenshotPageObject extends BasePageObject {
 
     const permutations = await this.browser.execute(getPermutationSizes);
 
-    // Restore window size after taking the screenshot
-    await this.safeSetWindowSize(originalWindowSize.width, originalWindowSize.height);
-
     if (permutations.length === 0) {
       throw new Error('No permutations found on current page.');
     }
 
     const screenshot = await this.fullPageScreenshot();
     const image = await parsePng(screenshot);
+
+    // Restore window size after taking the screenshot
+    await this.safeSetWindowSize(originalWindowSize.width, originalWindowSize.height);
 
     return permutations.map((permutation: PermutationInfo) => ({ ...permutation, image }));
   }


### PR DESCRIPTION
Restore the window size after taking the permutation screenshots, not before —otherwise scrollbars can unexpectedly shift the content for the screenshots and cause a mismatch with the previously taken measurements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
