### PR TITLE
chore: Take permutation screenshots before measuring them

### DIFF
--- a/src/page-objects/screenshot.ts
+++ b/src/page-objects/screenshot.ts
@@ -82,17 +82,16 @@ export default class ScreenshotPageObject extends BasePageObject {
     // Adapt viewport height to fit all elements before taking a screenshot
     const originalWindowSize = await this.fitWindowHeightToContent();
 
+    const screenshot = await this.fullPageScreenshot();
+    const image = await parsePng(screenshot);
     const permutations = await this.browser.execute(getPermutationSizes);
+
+    // Restore window size after taking the screenshot
+    await this.safeSetWindowSize(originalWindowSize.width, originalWindowSize.height);
 
     if (permutations.length === 0) {
       throw new Error('No permutations found on current page.');
     }
-
-    const screenshot = await this.fullPageScreenshot();
-    const image = await parsePng(screenshot);
-
-    // Restore window size after taking the screenshot
-    await this.safeSetWindowSize(originalWindowSize.width, originalWindowSize.height);
 
     return permutations.map((permutation: PermutationInfo) => ({ ...permutation, image }));
   }


### PR DESCRIPTION
When `capturePermutations` was introduced recently, it contained one small difference with respect to the internal implementation (see `CR-274228583`): calculate the permutation sizes before taking the actual permutation screenshots instead of the other way around. The reasoning was to return earlier in case permutations were not found.

However we are seeing flakiness in some visual regression tests which can be related to this. Let's change this back before adding workarounds such as hard-coded delays. The benefit of returning early is very small to non-existent anyway, as we don't expect permutations pages without permutations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
